### PR TITLE
fix #20

### DIFF
--- a/Drongengoed/Script/DRG-animal-tracking-for-REM.Rmd
+++ b/Drongengoed/Script/DRG-animal-tracking-for-REM.Rmd
@@ -107,9 +107,13 @@ seqID <- seqID[!seqID %in% seq_done]
 # 6 Open sequences in Agouti
 
 ```{r}
+project_id <- "e10e6b2b-78fc-44ad-9d66-c4d0b1dd889e"
+
 for (i in 1:length(seqID)) {
   # Open URL
-  browseURL(url = paste0("https://www.agouti.eu/project/e10e6b2b-78fc-44ad-9d66-c4d0b1dd889e/observations/edit-sequence/",
+  browseURL(url = paste0("https://www.agouti.eu/project/", 
+                         project_id, 
+                         "/annotate/sequence/",
                          seqID[i]))
   # append seqID to done file to skip next time
   write.table(data.frame(sequenceID = seqID[i]),

--- a/GMU8/Script/GMU8-tracking-animals-for-REM.Rmd
+++ b/GMU8/Script/GMU8-tracking-animals-for-REM.Rmd
@@ -127,9 +127,13 @@ This for-loop will open the relevant sequences one-by-one in Agouti. To ensure y
 * CANCEL/ANNULEREN: I have not annotated this sequence (for whaterver reason) and do not want to see the next sequence. *WARNING Check that this last sequenceID is not added to tracking_seq_done.csv. If yes, delete this (and ONLY this) seqID manually from tracking_seq_done.csv*
 
 ```{r open leftover seq in Agouti}
+project_id <- "91e1e104-a296-461e-af79-eeb6cb3e6c7f"
+
 for (i in 1:length(seqID)) {
   # Open URL
-  browseURL(url = paste0("https://www.agouti.eu/project/91e1e104-a296-461e-af79-eeb6cb3e6c7f/observations/edit-sequence/",
+    browseURL(url = paste0("https://www.agouti.eu/project/", 
+                         project_id, 
+                         "/annotate/sequence/",
                          seqID[i]))
   # append seqID to done file to skip next time
   write.table(data.frame(sequenceID = seqID[i]),

--- a/NPHK/Script/NPHK-check-doe-fawn-annotations.Rmd
+++ b/NPHK/Script/NPHK-check-doe-fawn-annotations.Rmd
@@ -47,9 +47,13 @@ seqID <- seqID[!seqID %in% seq_done]
 # Open sequences in Agouti
 
 ```{r}
+project_id <- "fed8eb80-9339-44ab-8801-de302be0357b"
+
 for (i in 1:length(seqID)) {
   # Open URL
-  browseURL(url = paste0("https://www.agouti.eu/project/fed8eb80-9339-44ab-8801-de302be0357b/observations/edit-sequence/",
+  browseURL(url = paste0("https://www.agouti.eu/project/", 
+                         project_id, 
+                         "/annotate/sequence/",
                          seqID[i]))
   # append seqID to done file to skip next time
   write.table(data.frame(sequenceID = seqID[i]),

--- a/Zonien/Script/ZS-animal-tracking-for-REM.Rmd
+++ b/Zonien/Script/ZS-animal-tracking-for-REM.Rmd
@@ -99,9 +99,13 @@ seqID <- seqID[!seqID %in% seq_done]
 # 6 Open sequences in Agouti
 
 ```{r}
+project_id <- "3b9f65bb-d7b9-49dd-8dd1-62e22a11e478"
+
 for (i in 1:length(seqID)) {
   # Open URL
-  browseURL(url = paste0("https://www.agouti.eu/project/3b9f65bb-d7b9-49dd-8dd1-62e22a11e478/observations/edit-sequence/",
+  browseURL(url = paste0("https://www.agouti.eu/project/", 
+                         project_id, 
+                         "/annotate/sequence/",
                          seqID[i]))
   # append seqID to done file to skip next time
   write.table(data.frame(sequenceID = seqID[i]),


### PR DESCRIPTION
This pull request refactors the process for opening sequences in Agouti across multiple R Markdown scripts by introducing a `project_id` variable and updating the URL construction logic. This change improves maintainability and consistency when referencing project-specific URLs.

**Refactoring and maintainability improvements:**

* Introduced a `project_id` variable in each script (`DRG-animal-tracking-for-REM.Rmd`, `GMU8-tracking-animals-for-REM.Rmd`, `NPHK-check-doe-fawn-annotations.Rmd`, `ZS-animal-tracking-for-REM.Rmd`) to avoid hardcoding project UUIDs directly in the URL. [[1]](diffhunk://#diff-f1566791c63153193db92bb6132260ff50ba9bde05a83d732824759cdf5eef97R110-R116) [[2]](diffhunk://#diff-ddb1b7b800a2a5754942d916324ee328a75a6bb210c9cb4449d24b194fb69186R130-R136) [[3]](diffhunk://#diff-ca9d78ba07959899547245c0b7bcac8320efc8ac463aff70aa81c37ffdd199fbR50-R56) [[4]](diffhunk://#diff-ff101edc03ae3144c3a0f34eb34a74826008e92de7ed61e7b2bf2a94b7903d7fR102-R108)
* Updated the `browseURL` call to construct the Agouti sequence annotation URL dynamically using the `project_id` variable and changed the URL path to use `/annotate/sequence/` instead of `/observations/edit-sequence/` for consistency and clarity. [[1]](diffhunk://#diff-f1566791c63153193db92bb6132260ff50ba9bde05a83d732824759cdf5eef97R110-R116) [[2]](diffhunk://#diff-ddb1b7b800a2a5754942d916324ee328a75a6bb210c9cb4449d24b194fb69186R130-R136) [[3]](diffhunk://#diff-ca9d78ba07959899547245c0b7bcac8320efc8ac463aff70aa81c37ffdd199fbR50-R56) [[4]](diffhunk://#diff-ff101edc03ae3144c3a0f34eb34a74826008e92de7ed61e7b2bf2a94b7903d7fR102-R108)