### PR TITLE
fix issues sequence filtering

### DIFF
--- a/GMU8/Script/GMU8-tracking-animals-for-REM.Rmd
+++ b/GMU8/Script/GMU8-tracking-animals-for-REM.Rmd
@@ -171,7 +171,7 @@ if(length(non_tracked_done) > 0){
 ```
 
 ```{r filter out seq_done}
-seqID <- seqID[!seqID %in% seq_done]
+seqID <- seqID[!seqID %in% seq_done$sequenceID]
 ```
 
 # 6 Open sequences in Agouti


### PR DESCRIPTION
This pull request makes a small update to how completed sequences are filtered out in the `GMU8-tracking-animals-for-REM.Rmd` script. The change ensures that only sequence IDs found in the `sequenceID` column of the `seq_done` data frame are removed from `seqID`, which improves the accuracy of the filtering process.